### PR TITLE
Rename voices method and allow all languages

### DIFF
--- a/lib/pollynomial/synthesizer.rb
+++ b/lib/pollynomial/synthesizer.rb
@@ -38,9 +38,8 @@ module Pollynomial
       end
     end
 
-    def available_voices_in(language_code: 'en-US')
-      voices = client.describe_voices(language_code: language_code)
-      voices.voices if voices
+    def voices(language=nil)
+      client.describe_voices(language_code: language).voices
     end
 
     def split_text(raw_text)


### PR DESCRIPTION
This PR renames the method `#available_voices_in` to `#voices`, and in addition, allows getting voices in all languages in one call.

Example usage:

```ruby
synth = Pollynomial::Synthesizer.new

# Get English/US voices
p synth.voices 'en-US'

# Get all voices
p synth.voices
```

Closes #1 